### PR TITLE
Bug fixes and various improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.save
 coverage
+DerivedData

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+os: osx
+language: ruby
+rvm: system
+script: rake build

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,12 @@ end
 
 desc "build RubyCocoa.framework"
 task :build do
+  require 'rbconfig'
+  target_arch = RbConfig::CONFIG['target_cpu']
+
   config = ["config"]
+  config << "--target-archs=#{target_arch}" if target_arch != 'universal'
+
   ruby "install.rb", *config
   ruby "install.rb", "setup"
   ruby "install.rb", "test"

--- a/framework/src/objc/RBObject.m
+++ b/framework/src/objc/RBObject.m
@@ -452,7 +452,7 @@ VALUE rbobj_call_ruby(id rbobj, SEL selector, VALUE args)
       char encoding[128], *p;
 
       if (argc < 0)
-        argc = -1 - argc;
+        argc = -argc;
       argc = MIN(sizeof(encoding) - 4, argc);
 
       strcpy(encoding, "@@:");

--- a/framework/src/objc/ocdata_conv.h
+++ b/framework/src/objc/ocdata_conv.h
@@ -76,6 +76,8 @@ BOOL  ocdata_to_rbobj (VALUE context_obj,
 		       const char *octype, const void* ocdata, VALUE* result, BOOL from_libffi);
 BOOL  rbobj_to_ocdata (VALUE obj, const char *octype, void* ocdata, BOOL to_libffi);
 
+BOOL rbobj_to_collection_safe_nsobj (VALUE obj, id* nsobj);
+
 void init_rb2oc_cache(void);
 void init_oc2rb_cache(void);
 void clear_oc2rb_cache(void);

--- a/framework/src/objc/ocdata_conv.m
+++ b/framework/src/objc/ocdata_conv.m
@@ -472,7 +472,7 @@ rbary_to_nsary (VALUE rbary, id* nsary)
   ASSERT_ALLOC(objects);
   
   for (i = 0; i < len; i++)
-    if (!rbobj_to_nsobj(RARRAY_PTR(rbary)[i], &objects[i]))
+    if (!rbobj_to_collection_safe_nsobj(RARRAY_PTR(rbary)[i], &objects[i]))
       return NO;
   
   *nsary = [[[NSMutableArray alloc] initWithObjects:objects count:len] autorelease];
@@ -501,10 +501,10 @@ rbhash_to_nsdic (VALUE rbhash, id* nsdic)
   ASSERT_ALLOC(nsvals);
 
   for (i = 0; i < len; i++) {
-    if (!rbobj_to_nsobj(keys[i], &nskeys[i])) 
+    if (!rbobj_to_collection_safe_nsobj(keys[i], &nskeys[i]))
       return NO;
     val = rb_hash_aref(rbhash, keys[i]);
-    if (!rbobj_to_nsobj(val, &nsvals[i])) 
+    if (!rbobj_to_collection_safe_nsobj(val, &nsvals[i]))
       return NO;
   }
 
@@ -637,6 +637,16 @@ rbobj_to_nsobj (VALUE obj, id* nsobj)
   }
 
   return ok;
+}
+
+BOOL
+rbobj_to_collection_safe_nsobj (VALUE obj, id* nsobj)
+{
+  if (obj == Qnil) {
+    *nsobj = [NSNull null];
+    return YES;
+  }
+  return rbobj_to_nsobj(obj, nsobj);
 }
 
 BOOL 

--- a/framework/src/ruby/osx/objc/oc_import.rb
+++ b/framework/src/ruby/osx/objc/oc_import.rb
@@ -6,6 +6,7 @@
 # LGPL. See the COPYRIGHT file for more information.
 
 require 'osx/objc/oc_wrapper'
+require 'osx/objc/oc_exception'
 
 module OSX
 

--- a/pre-config.rb
+++ b/pre-config.rb
@@ -17,9 +17,6 @@ install_path = @config['build-as-embeddable'] == 'yes' \
 config_ary = [
   [ :frameworks,      @config['frameworks'] ],
   [ :ruby_header_paths, [@config['ruby-header-dir'], @config['ruby-archheader-dir']].uniq.join(' ') ],
-  [ :libruby_path,    @config['libruby-path'] ],
-  [ :libruby_path_dirname,  File.dirname(@config['libruby-path']) ],
-  [ :libruby_path_basename, File.basename(@config['libruby-path']) ],
   [ :rubycocoa_version,      @config['rubycocoa-version'] ],
   [ :rubycocoa_version_short,   @config['rubycocoa-version-short'] ],
   [ :rubycocoa_release_date, @config['rubycocoa-release-date'] ],
@@ -36,6 +33,15 @@ ldflags = '-undefined suppress -flat_namespace'
 sdkroot = @config['sdkroot']
 archs = @config['target-archs']
 other_header_search_paths = []
+
+# do not link statib ruby into the framework
+if RbConfig::CONFIG["ENABLE_SHARED"] == 'yes'
+  config_ary << [ :libruby_path, @config['libruby-path'] ]
+  config_ary << [ :libruby_path_dirname, File.dirname(@config['libruby-path']) ]
+else
+  config_ary << [ :libruby_path, '' ]
+  config_ary << [ :libruby_path_dirname, '' ]
+end
 
 # add archs if given
 arch_flags = archs.gsub(/\A|\s+/, ' -arch ')
@@ -59,8 +65,6 @@ if lib_exist?('/usr/include/libxml2') and
 else
   raise "ERROR: libxml2 not found!"
 end
-
-raise 'ERROR: ruby must be built as a shared library' if RbConfig::CONFIG["ENABLE_SHARED"] != 'yes'
 
 # Add the libffi library to the build process.
 if !lib_exist?('/usr/lib/libffi.a') and

--- a/test/objc_test.m
+++ b/test/objc_test.m
@@ -250,9 +250,10 @@
 @interface CallerClass : NSObject
 @end
 
-@interface NSObject (TcSubclassFoo)
+@interface NSObject (CallerClassSelectors)
 
 - (long)calledFoo:(id)arg;
+- (id)optional_arg:(id)arg :(id)optional_arg;
 
 @end
 
@@ -261,6 +262,11 @@
 - (id)callFoo:(id)receiver
 {
     return (id)[receiver calledFoo:nil];
+}
+
++ (id)callOnReceiver:(id)receiver arg:(id)arg optionalArg:(id)optionalArg;
+{
+    return (id)[receiver optional_arg:arg :optionalArg];
 }
 
 @end

--- a/test/test_dispatch.rb
+++ b/test/test_dispatch.rb
@@ -1,0 +1,19 @@
+require 'test/unit'
+require 'osx/cocoa'
+
+system 'make -s' || raise(RuntimeError, "'make' failed")
+require './objc_test.bundle'
+
+class DispatchReceiver
+  def optional_arg(arg, optional_arg = nil)
+    [arg, optional_arg]
+  end
+end
+
+class TC_Dispatch < Test::Unit::TestCase
+  def test_optional_arg
+    receiver = DispatchReceiver.new
+    result = OSX::CallerClass.callOnReceiver_arg_optionalArg(receiver, 'arg', 'optional_arg')
+    assert_equal ['arg', 'optional_arg'], result
+  end
+end

--- a/test/test_nsarray.rb
+++ b/test/test_nsarray.rb
@@ -1,6 +1,9 @@
 require 'test/unit'
 require 'osx/cocoa'
 
+system 'make -s' || raise(RuntimeError, "'make' failed")
+require './objc_test.bundle'
+
 class TC_NSArray < Test::Unit::TestCase
   include OSX
   
@@ -958,5 +961,11 @@ class TC_NSArray < Test::Unit::TestCase
       assert_equal(y, x.to_ruby)
       assert_kind_of(NSArray, x)
     end
+  end
+
+  def test_nil_protection
+    receiver = Object.new
+    def receiver.calledFoo(_); [nil]; end
+    assert_equal([NSNull.null].to_ns, CallerClass.new.callFoo(receiver))
   end
 end

--- a/test/test_nsdictionary.rb
+++ b/test/test_nsdictionary.rb
@@ -1,6 +1,9 @@
 require 'test/unit'
 require 'osx/cocoa'
 
+system 'make -s' || raise(RuntimeError, "'make' failed")
+require './objc_test.bundle'
+
 class TC_NSDictionary < Test::Unit::TestCase
   include OSX
   
@@ -334,5 +337,11 @@ class TC_NSDictionary < Test::Unit::TestCase
     x = a.values_at(3,5,4)
     y = b.values_at(3,5,4)
     assert_equal(y, x.to_ruby)
+  end
+
+  def test_nil_protection
+    receiver = Object.new
+    def receiver.calledFoo(_); { nil => nil }; end
+    assert_equal({ NSNull.null => NSNull.null }.to_ns, CallerClass.new.callFoo(receiver))
   end
 end


### PR DESCRIPTION
Hey @kimuraw san!

Long time no speak :)

I’ve started using RubyCocoa again in CocoaPods.app https://github.com/CocoaPods/CocoaPods-app/pull/103. During this process I came across a few minor issues, such as:
- The configuration did not allow linking against a static libruby. I’m not sure why that is a problem? It works fine in my testing.
- The `rake build` task did not take the target archs of the host Ruby into account and always assumed universal.
- When trying to require only `oc_import.rb` a `LoadError` would occur.
- I’m not sure what the logic around a negative arity was supposed to do, but my guess was that it tried to make the number absolute? I’ve fixed that and now bridging methods with optional parameters works again in my app.
- When converting a `Hash` or `Array` to `NSDictionary` or `NSArray`, do not try to insert `nil`.

I might have more changes to come in the future as I work on this integration, but for now I wanted to get this party started :tada: 
